### PR TITLE
Updated the upstart conf to prevent any ASCII errors

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sander@xanzy.io'
 license          'Apache 2.0'
 description      'Installs/Configures Chef-Guard'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4'
+version          '0.1.5'
 
 %w(redhat centos ubuntu).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,6 +59,7 @@ template '/etc/init/chef-guard.conf' do
     :template_file => source.to_s,
     :basedir => node['chef-guard']['install_dir']
   )
+  notifies :reload, 'service[chef-guard]'
 end
 
 template "#{node['chef-guard']['install_dir']}/chef-guard.conf" do

--- a/templates/default/chef-guard.upstart.erb
+++ b/templates/default/chef-guard.upstart.erb
@@ -10,6 +10,9 @@ description "Chef-Guard"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+env LANG=en_US.UTF-8
+export LANG
+
 respawn
 
 exec <%= @basedir %>/chef-guard >> <%= @basedir %>/console.log


### PR DESCRIPTION
Currently some foodcritic tests fail without this env setting
