### PR TITLE
Capture stderr into logfile

### DIFF
--- a/templates/default/chef-guard.upstart.erb
+++ b/templates/default/chef-guard.upstart.erb
@@ -15,4 +15,4 @@ export LANG
 
 respawn
 
-exec <%= @basedir %>/chef-guard >> <%= @basedir %>/console.log
+exec <%= @basedir %>/chef-guard >> <%= @basedir %>/console.log 2>&1


### PR DESCRIPTION
Here's an example before this change:
```
# start chef-guard
chef-guard start/running, process 10746

# cat /opt/chef-guard/console.log
```

After the change:
```
# cat /opt/chef-guard/console.log
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailRecipient
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->GitCookbookOrgs
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailRecipient
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailRecipient
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->MailServer
2015/03/11 21:25:40 Required configuration value missing for Section->Key: Default->GitCookbookOrgs
```