### PR TITLE
Add /api/v3 to serveurl in example

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,7 +96,7 @@ default['chef-guard']['config']['tests']['rubocop']    = '/opt/chef/embedded/bin
 #  'token' => 'xxx'
 #}
 #default['chef-guard']['config']['github']['org2'] = {
-#  'serverurl' => 'https://github.company.com', => url to your Github Enterprise appliance
+#  'serverurl' => 'https://github.company.com/api/v3', => url to your Github Enterprise appliance
 #  'sslnoverify' => false,
 #  'token' => 'xxx'
 #}


### PR DESCRIPTION
I'm using Github Enterprise and Github OAuth.
Chef-Guard was giving me an error before I added '/api/v3' to the end of serverurl:
```
ERROR:  Failed to update node-01 node for anton in Github: invalid character '<' looking for beginning of value
```

Since most of cookbook users just uncomment example attributes (like me) it's better to provide the right format in example.