### PR TITLE
Remove do in if and use unless without block

### DIFF
--- a/templates/default/cg_foodcritic_tests.rb.erb
+++ b/templates/default/cg_foodcritic_tests.rb.erb
@@ -46,13 +46,11 @@ rule 'CG001', 'Ensure all cookbook dependencies depend on a specific version' do
     matches = []
     name = ast.xpath(%q{//command[ident/@value='name']})
 
-    if name.to_s.match('<%= @matches %>') do 
+    if name.to_s.match('<%= @matches %>')
       # Get and loop through the hash with dependencies
       # and check if they depend on a specific version
       dependency_versions(ast).each do |name,version|
-        unless version.to_s != '' && /^(?:= )?\d+\.\d+\.\d+$/ === version.xpath(%q{@value}).to_s
-          matches << name
-        end
+        matches << name unless version.to_s != '' && /^(?:= )?\d+\.\d+\.\d+$/ === version.xpath(%q{@value}).to_s
       end
     end
     matches


### PR DESCRIPTION
This file was causing:
```
ERROR:   2015/08/07 10:47:15 Failed to execute foodcritic tests: .../embedded/lib/ruby/gems/1.9.1/gems/foodcritic-4.0.0/lib/foodcritic/dsl.rb:80:in `instance_eval': .../cg_foodcritic_tests.rb:60: syntax error, unexpected $end, expecting keyword_end (SyntaxError)
        ...
 - exit status 1
```