### PR TITLE
Fix logic error in chef-guard.conf.erb template

### DIFF
--- a/templates/default/chef-guard.conf.erb
+++ b/templates/default/chef-guard.conf.erb
@@ -52,7 +52,7 @@
 <% end -%>
 <% end -%>
 
-<% if @config['chef']['type'] == "enterprise" || @config['chef']['version'] > 11 && !@config['customers'].nil? -%>
+<% if (@config['chef']['type'] == "enterprise" || @config['chef']['version'] > 11) && !@config['customers'].nil? -%>
 <% @config['customers'].each do |k,v| -%>
 [customer "<%= k %>"]
   <% v.each do |subk,subv| -%>


### PR DESCRIPTION
If the customers config is empty, the cookbook throws a TemplateError: "undefined method `each' for nil:NilClass"