### PR TITLE
Fix attributes file and chef-vault for Chef 13+

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ default['chef-guard']['install_dir']   = '/opt/chef-guard'
 default['chef-guard']['vault']         = 'chef-guard'
 default['chef-guard']['vault_item']    = 'chef.bookshelf'
 
-if kernel['machine'] =~ /x86_64/
+if node['kernel']['machine'] == 'x86_64'
   default['chef-guard']['url']      = "https://github.com/xanzy/chef-guard/releases/download/v#{node['chef-guard']['version']}/chef-guard-v#{node['chef-guard']['version']}-linux-x64.tar.gz"
   default['chef-guard']['checksum'] = '922e07e452e04728e7de7ee816f58afff853b0513e5bfbcde5527ec1d9a39940'
 else

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-chef_gem "chef-vault"
+chef_gem "chef-vault" do
+  compile_time true
+end
 require 'chef-vault'
 
 # First get the needed bookshelf key and secret from a Chef-Vault


### PR DESCRIPTION
Without these changes Chef 13+ throws `undefined method 'kernel' for #<Chef::Node::Attribute:0x00000004209640>` and `cannot load such file -- chef-vault`